### PR TITLE
Add `outputmargin = TRUE` in `predict` of a xgboost model

### DIFF
--- a/R/model_fit.R
+++ b/R/model_fit.R
@@ -395,7 +395,7 @@ xgb_cox_fit <- function(train,
                    nrounds = cv_fit$best_iteration)
 
   # baseline hazard estimate at pred horizon
-  lin_preds <- predict(fit, newdata = xmat)
+  lin_preds <- predict(fit, newdata = xmat, outputmargin = TRUE)
 
   base_haz <-
     gbm::basehaz.gbm(t = train[, 'time'],

--- a/R/model_pred.R
+++ b/R/model_pred.R
@@ -206,7 +206,7 @@ xgb_cox_pred <- function(object, test, pred_horizon){
 
   start_time <- Sys.time()
 
-  lin_preds <- predict(object$fit, newdata = .test)
+  lin_preds <- predict(object$fit, newdata = .test, outputmargin = TRUE)
 
   for(i in seq_along(pred_horizon)){
     res[, i] <- exp(exp(lin_preds) * -object$base_haz[i])


### PR DESCRIPTION
Dear Maintainer,

I'm trying to train a `xgboost` model with the Cox proportional hazard loss using your codes.
You estimated the baseline cumulative hazard $H_0(t)$ by `gbm::basehaz.gbm`.

https://github.com/bcjaeger/aorsf-bench/blob/c8a9b5b6fd1caa078c50bad52664c5cb993b1268/R/model_fit.R#L397-L406

I search its document and see that the parameter `f.x` needs to be the predicted values of the regression model on the ***log hazard*** scale. However, you passed the output of `predict(fit, newdata = xmat)` into it, where the `predict` method for class `'xgb.Booster'` defaults to return predictions on the ***hazard ratio*** scale (i.e., as $HR = exp(X\beta)$ in the proportional hazard function $h(t) = h_0(t) * HR$), instead of log hazard scale $log(HR) = X\beta$.

I think you may need to set `outputmargin = TRUE` before passing it into `basehaz.gbm`, i.e.

```
lin_preds <- predict(fit, newdata = xmat, outputmargin = TRUE)
```

`outputmargin` controls whether the predictions should be returned in the form of original untransformed sum of predictions from boosting iterations' results.

---

The same issue appears in the `xgb_cox_pred` function from `model_pred.R`.

https://github.com/bcjaeger/aorsf-bench/blob/c8a9b5b6fd1caa078c50bad52664c5cb993b1268/R/model_pred.R#L209-L213

It seems that you use the formula $S(t) = exp(exp(X\beta) * -H_0(t))$ to evaluate survival probabilities. `lin_preds` you define has been $exp(X\beta)$, and you take one more `exp()` outside of it. So I think you also need to set `outputmargin = TRUE` here.

Maybe all above are my misunderstanding! Thank you for any replies. This project is an outstanding work!

Best regards,
